### PR TITLE
LESSON9-3-7 Edit link

### DIFF
--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -7,7 +7,7 @@
         Member :
         - @group.group_users.each do |group_user|
           = group_user.user.name
-    =link_to "#", class: "main-header__edit-btn" do
+    =link_to edit_group_path(@group), class: "main-header__edit-btn" do
       Edit
   .messages
     = render @messages


### PR DESCRIPTION
# What
Chat-Spaseのグループチャットの画面にてEditボタンから該当グループのグループ編集画面にリンクするように修正

# why
グループの編集画面へアクセス出来ない状態だったため