### PR TITLE
LESSON9-3-9 Group-Edit Redirect

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -20,7 +20,7 @@ class GroupsController < ApplicationController
 
   def update
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(@group), notice: 'グループを更新しました'
     else
       render :edit
     end


### PR DESCRIPTION
# What
Chat-Spaseのグループ編集画面からトップ画面に遷移していた処理を基のグループを表示する処理に修正した。

# Why
編集した内容を確認しやすいため。